### PR TITLE
Add helper to check for validation errors

### DIFF
--- a/yakiniku48-mailform.php
+++ b/yakiniku48-mailform.php
@@ -309,6 +309,11 @@ EOM;
 			}
 		}
 
+		public function has_errors()
+		{
+			return ! empty( $this->validation_errors );
+		}
+
 		public function validation_add_affix( $string )
 		{
 			return '<p class="y48mf-error">' . $string . '</p>';


### PR DESCRIPTION
## Summary
- add `has_errors` method to YAKINIKU48_MailForm for checking validation state

## Testing
- `php -l yakiniku48-mailform.php`


------
https://chatgpt.com/codex/tasks/task_e_689bf090031c8331ae39088e6f139b24