### PR TITLE
Rename helper to has_validation_errors

### DIFF
--- a/yakiniku48-mailform.php
+++ b/yakiniku48-mailform.php
@@ -309,7 +309,12 @@ EOM;
 			}
 		}
 
-		public function has_errors()
+		/**
+		 * Check if any validation errors exist.
+		 *
+		 * @return bool True if there are validation errors.
+		 */
+		public function has_validation_errors()
 		{
 			return ! empty( $this->validation_errors );
 		}


### PR DESCRIPTION
## Summary
- rename `has_errors` helper to `has_validation_errors`
- document the helper with a docblock

## Testing
- `php -l yakiniku48-mailform.php`


------
https://chatgpt.com/codex/tasks/task_e_689bf3a2b62c8331afe7a62f4629f0ed